### PR TITLE
Fix incorrect noTickViewDistance hook

### DIFF
--- a/src/main/java/com/froobworld/viewdistancetweaks/placeholder/VdtExpansion.java
+++ b/src/main/java/com/froobworld/viewdistancetweaks/placeholder/VdtExpansion.java
@@ -61,7 +61,7 @@ public class VdtExpansion extends PlaceholderExpansion {
             } else if (params.startsWith("no_tick_view_distance_")) {
                 world = Bukkit.getWorld(params.replace("no_tick_view_distance_", ""));
             }
-            return world == null ? null : ("" + viewDistanceTweaks.getHookManager().getViewDistanceHook().getViewDistance(world));
+            return world == null ? null : ("" + noTickViewDistanceHook.getViewDistance(world));
         }
 
         if (params.startsWith("tick_chunk_count")) {


### PR DESCRIPTION
PAPI displayed normal view distance instead notick view distance

I think it was a little typo :)