### PR TITLE
Add option for adjusting view distance in reactive mode

### DIFF
--- a/src/main/java/com/froobworld/viewdistancetweaks/config/VdtConfig.java
+++ b/src/main/java/com/froobworld/viewdistancetweaks/config/VdtConfig.java
@@ -11,7 +11,7 @@ import org.bukkit.World;
 import java.io.File;
 
 public class VdtConfig extends NabConfiguration {
-    public static final int VERSION = 8;
+    public static final int VERSION = 9;
 
     public VdtConfig(ViewDistanceTweaks viewDistanceTweaks) {
         super(
@@ -51,11 +51,24 @@ public class VdtConfig extends NabConfiguration {
         @Entry(key = "increase-mspt-threshold")
         public final ConfigEntry<Double> increaseMsptThreshold = ConfigEntries.doubleEntry();
 
+        @Section(key = "reactive-view-distance")
+        public final ReactiveViewDistanceSettings reactiveViewDistance = new ReactiveModeSettings.ReactiveViewDistanceSettings();
+
         @Section(key = "mspt-prediction")
         public final ReactiveModeSettings.MsptPredictionSettings msptPrediction = new ReactiveModeSettings.MsptPredictionSettings();
 
         @Section(key = "mspt-tracker-settings")
         public final ReactiveModeSettings.MsptTrackerSettings msptTracker = new ReactiveModeSettings.MsptTrackerSettings();
+
+        public static class ReactiveViewDistanceSettings extends ConfigSection {
+
+            @Entry(key = "use-reactive-view-distance")
+            public final ConfigEntry<Boolean> useReactiveViewDistance = new ConfigEntry<>();
+
+            @Entry(key = "target-view-distance-ratio")
+            public final ConfigEntry<Double> targetViewDistanceRatio = ConfigEntries.doubleEntry();
+
+        }
 
         public static class MsptTrackerSettings extends ConfigSection {
 

--- a/src/main/java/com/froobworld/viewdistancetweaks/limiter/ViewDistanceLimiter.java
+++ b/src/main/java/com/froobworld/viewdistancetweaks/limiter/ViewDistanceLimiter.java
@@ -15,7 +15,6 @@ public class ViewDistanceLimiter implements Runnable {
     private final SimulationDistanceHook simulationDistanceHook;
     private final AdjustmentMode adjustmentMode;
     private final ManualViewDistanceManager manualViewDistanceManager;
-    private final Set<ViewDistanceChangeTask> changeViewDistanceTasks = new HashSet<>();
     private final boolean logChanges;
     private final String logFormat;
     private Integer taskId;
@@ -32,30 +31,25 @@ public class ViewDistanceLimiter implements Runnable {
 
     @Override
     public void run() {
-        if (changeViewDistanceTasks.isEmpty()) {
-            List<World> nonEmptyWorlds = Bukkit.getWorlds().stream()
-                    .filter(world -> !world.getPlayers().isEmpty())
-                    .filter(world -> !manualViewDistanceManager.hasManuallySetViewDistance(world))
-                    .collect(Collectors.toList());
-            Map<World, AdjustmentMode.Adjustment> adjustments = nonEmptyWorlds.isEmpty() ? Collections.emptyMap() : adjustmentMode.getAdjustments(nonEmptyWorlds);
+        List<World> nonEmptyWorlds = Bukkit.getWorlds().stream()
+                .filter(world -> !world.getPlayers().isEmpty())
+                .filter(world -> !manualViewDistanceManager.hasManuallySetViewDistance(world))
+                .collect(Collectors.toList());
+        Map<World, AdjustmentMode.Adjustment> adjustments = nonEmptyWorlds.isEmpty() ? Collections.emptyMap() : adjustmentMode.getAdjustments(nonEmptyWorlds);
 
-            for (Map.Entry<World, AdjustmentMode.Adjustment> entry : adjustments.entrySet()) {
-                World world = entry.getKey();
-                AdjustmentMode.Adjustment adjustment = entry.getValue();
-                int oldViewDistance = simulationDistanceHook.getDistance(world);
+        for (Map.Entry<World, AdjustmentMode.Adjustment> entry : adjustments.entrySet()) {
+            World world = entry.getKey();
+            AdjustmentMode.Adjustment adjustment = entry.getValue();
+            int oldViewDistance = simulationDistanceHook.getDistance(world);
 
-                if (adjustment != AdjustmentMode.Adjustment.STAY) {
-                    int newViewDistance = oldViewDistance + (adjustment == AdjustmentMode.Adjustment.INCREASE ? 1 : -1);
-                    ViewDistanceChangeTask changeTask = new ViewDistanceChangeTask(viewDistanceTweaks, simulationDistanceHook, world, newViewDistance, 0);
-                    changeTask.run();
-                    changeViewDistanceTasks.add(changeTask);
-                    if (logChanges) {
-                        viewDistanceTweaks.getLogger().info(MessageFormat.format(logFormat, world.getName(), oldViewDistance, newViewDistance));
-                    }
+            if (adjustment != AdjustmentMode.Adjustment.STAY) {
+                int newViewDistance = oldViewDistance + (adjustment == AdjustmentMode.Adjustment.INCREASE ? 1 : -1);
+                simulationDistanceHook.setDistance(world, newViewDistance);
+                if (logChanges) {
+                    viewDistanceTweaks.getLogger().info(MessageFormat.format(logFormat, world.getName(), oldViewDistance, newViewDistance));
                 }
             }
         }
-        changeViewDistanceTasks.removeIf(ViewDistanceChangeTask::completed);
     }
 
     public void start(long period, long startUpDelay) {
@@ -68,8 +62,6 @@ public class ViewDistanceLimiter implements Runnable {
     public void cancel() {
         if (taskId != null) {
             Bukkit.getScheduler().cancelTask(taskId);
-            changeViewDistanceTasks.forEach(ViewDistanceChangeTask::cancel);
-            changeViewDistanceTasks.clear();
             taskId = null;
         }
     }

--- a/src/main/java/com/froobworld/viewdistancetweaks/limiter/adjustmentmode/AdjustmentMode.java
+++ b/src/main/java/com/froobworld/viewdistancetweaks/limiter/adjustmentmode/AdjustmentMode.java
@@ -7,7 +7,11 @@ import java.util.Map;
 
 public interface AdjustmentMode {
 
-    Map<World, Adjustment> getAdjustments(Collection<World> worlds);
+    Map<World, Adjustment> getAdjustments(Collection<World> worlds, boolean mutate);
+
+    default Map<World, Adjustment> getAdjustments(Collection<World> worlds) {
+        return getAdjustments(worlds, true);
+    }
 
     enum Adjustment {
         INCREASE,

--- a/src/main/java/com/froobworld/viewdistancetweaks/limiter/adjustmentmode/AdjustmentModes.java
+++ b/src/main/java/com/froobworld/viewdistancetweaks/limiter/adjustmentmode/AdjustmentModes.java
@@ -1,0 +1,181 @@
+package com.froobworld.viewdistancetweaks.limiter.adjustmentmode;
+
+import com.froobworld.viewdistancetweaks.ViewDistanceTweaks;
+import com.froobworld.viewdistancetweaks.hook.viewdistance.SimulationDistanceHook;
+import com.froobworld.viewdistancetweaks.hook.viewdistance.ViewDistanceHook;
+import org.bukkit.World;
+
+import java.util.Collection;
+import java.util.Map;
+
+public class AdjustmentModes {
+    private final ViewDistanceTweaks viewDistanceTweaks;
+    private AdjustmentMode sdAdjustmentMode;
+    private AdjustmentMode vdAdjustmentMode;
+
+    public AdjustmentModes(ViewDistanceTweaks viewDistanceTweaks) {
+        this.viewDistanceTweaks = viewDistanceTweaks;
+    }
+
+    public AdjustmentMode getSimulationDistanceAdjustmentMode() {
+        return sdAdjustmentMode;
+    }
+
+    public AdjustmentMode getViewDistanceAdjustmentMode() {
+        return vdAdjustmentMode;
+    }
+
+    public void init() {
+        AdjustmentMode.Mode mode = viewDistanceTweaks.getVdtConfig().adjustmentMode.get();
+
+        AdjustmentMode sdProactiveAdjustmentMode = null;
+        AdjustmentMode sdReactiveAdjustmentMode = null;
+        if (mode == AdjustmentMode.Mode.REACTIVE || mode == AdjustmentMode.Mode.MIXED) {
+            sdReactiveAdjustmentMode = new ReactiveAdjustmentMode(
+                    viewDistanceTweaks.getTaskManager().getMsptTracker(),
+                    viewDistanceTweaks.getHookManager().getChunkCounter(),
+                    viewDistanceTweaks.getVdtConfig().reactiveMode.increaseMsptThreshold.get(),
+                    viewDistanceTweaks.getVdtConfig().reactiveMode.decreaseMsptThreshold.get(),
+                    viewDistanceTweaks.getVdtConfig().reactiveMode.msptPrediction.historyLength.get(),
+                    viewDistanceTweaks.getVdtConfig().reactiveMode.msptPrediction.enabled.get(),
+                    viewDistanceTweaks.getHookManager().getSimulationDistanceHook(),
+                    world -> viewDistanceTweaks.getVdtConfig().worldSettings.of(world).simulationDistance.exclude.get(),
+                    world -> viewDistanceTweaks.getVdtConfig().worldSettings.of(world).simulationDistance.maximumSimulationDistance.get(),
+                    world -> viewDistanceTweaks.getVdtConfig().worldSettings.of(world).simulationDistance.minimumSimulationDistance.get(),
+                    viewDistanceTweaks.getVdtConfig().passedChecksForIncrease.get(),
+                    viewDistanceTweaks.getVdtConfig().passedChecksForDecrease.get()
+            );
+        }
+        if (mode == AdjustmentMode.Mode.PROACTIVE || mode == AdjustmentMode.Mode.MIXED) {
+            sdProactiveAdjustmentMode = new ProactiveAdjustmentMode(
+                    viewDistanceTweaks.getVdtConfig().proactiveMode.globalTickingChunkCountTarget.get(),
+                    viewDistanceTweaks.getHookManager().getSimulationDistanceHook(),
+                    viewDistanceTweaks.getHookManager().getChunkCounter(),
+                    world -> viewDistanceTweaks.getVdtConfig().worldSettings.of(world).simulationDistance.exclude.get(),
+                    world -> viewDistanceTweaks.getVdtConfig().worldSettings.of(world).simulationDistance.maximumSimulationDistance.get(),
+                    world -> viewDistanceTweaks.getVdtConfig().worldSettings.of(world).simulationDistance.minimumSimulationDistance.get(),
+                    viewDistanceTweaks.getVdtConfig().passedChecksForIncrease.get(),
+                    viewDistanceTweaks.getVdtConfig().passedChecksForDecrease.get()
+            );
+        }
+
+        AdjustmentMode vdProactiveAdjustmentMode = null;
+        AdjustmentMode vdReactiveAdjustmentMode = null;
+        if (viewDistanceTweaks.getHookManager().getViewDistanceHook() != null) {
+            if ((mode == AdjustmentMode.Mode.REACTIVE || mode == AdjustmentMode.Mode.MIXED) && viewDistanceTweaks.getVdtConfig().reactiveMode.reactiveViewDistance.useReactiveViewDistance.get()) {
+                vdReactiveAdjustmentMode = new ReactiveAdjustmentMode(
+                        viewDistanceTweaks.getTaskManager().getMsptTracker(),
+                        viewDistanceTweaks.getHookManager().getNoTickChunkCounter(),
+                        viewDistanceTweaks.getVdtConfig().reactiveMode.increaseMsptThreshold.get(),
+                        viewDistanceTweaks.getVdtConfig().reactiveMode.decreaseMsptThreshold.get(),
+                        viewDistanceTweaks.getVdtConfig().reactiveMode.msptPrediction.historyLength.get(),
+                        false, // no MSPT prediction for view distance
+                        viewDistanceTweaks.getHookManager().getViewDistanceHook(),
+                        world -> viewDistanceTweaks.getVdtConfig().worldSettings.of(world).viewDistance.exclude.get(),
+                        world -> viewDistanceTweaks.getVdtConfig().worldSettings.of(world).viewDistance.maximumViewDistance.get(),
+                        world -> viewDistanceTweaks.getVdtConfig().worldSettings.of(world).viewDistance.minimumViewDistance.get(),
+                        viewDistanceTweaks.getVdtConfig().passedChecksForIncrease.get(),
+                        viewDistanceTweaks.getVdtConfig().passedChecksForDecrease.get()
+                );
+            }
+            if (mode == AdjustmentMode.Mode.PROACTIVE || mode == AdjustmentMode.Mode.MIXED || !viewDistanceTweaks.getVdtConfig().reactiveMode.reactiveViewDistance.useReactiveViewDistance.get()) {
+                vdProactiveAdjustmentMode = new ProactiveAdjustmentMode(
+                        viewDistanceTweaks.getVdtConfig().proactiveMode.globalNonTickingChunkCountTarget.get(),
+                        viewDistanceTweaks.getHookManager().getViewDistanceHook(),
+                        viewDistanceTweaks.getHookManager().getNoTickChunkCounter(),
+                        world -> viewDistanceTweaks.getVdtConfig().worldSettings.of(world).viewDistance.exclude.get(),
+                        world -> viewDistanceTweaks.getVdtConfig().worldSettings.of(world).viewDistance.maximumViewDistance.get(),
+                        world -> viewDistanceTweaks.getVdtConfig().worldSettings.of(world).viewDistance.minimumViewDistance.get(),
+                        viewDistanceTweaks.getVdtConfig().passedChecksForIncrease.get(),
+                        viewDistanceTweaks.getVdtConfig().passedChecksForDecrease.get()
+                );
+            }
+        }
+        if (sdReactiveAdjustmentMode != null && vdReactiveAdjustmentMode != null) {
+            double ratio = Math.max(1, viewDistanceTweaks.getVdtConfig().reactiveMode.reactiveViewDistance.targetViewDistanceRatio.get());
+            AdjustmentMode newSdReactiveAdjustmentMode = new RatioPreservingAdjustmentMode(
+                    ratio,
+                    RatioPreservingAdjustmentMode.Type.SIMULATION_DISTANCE,
+                    sdReactiveAdjustmentMode,
+                    vdReactiveAdjustmentMode,
+                    viewDistanceTweaks.getHookManager().getSimulationDistanceHook(),
+                    viewDistanceTweaks.getHookManager().getViewDistanceHook()
+            );
+            AdjustmentMode newVdReactiveAdjustmentMode = new RatioPreservingAdjustmentMode(
+                    ratio,
+                    RatioPreservingAdjustmentMode.Type.VIEW_DISTANCE,
+                    sdReactiveAdjustmentMode,
+                    vdReactiveAdjustmentMode,
+                    viewDistanceTweaks.getHookManager().getSimulationDistanceHook(),
+                    viewDistanceTweaks.getHookManager().getViewDistanceHook()
+            );
+            sdReactiveAdjustmentMode = newSdReactiveAdjustmentMode;
+            vdReactiveAdjustmentMode = newVdReactiveAdjustmentMode;
+        }
+        this.sdAdjustmentMode = sdProactiveAdjustmentMode == null ? sdReactiveAdjustmentMode
+                : (sdReactiveAdjustmentMode == null ? sdProactiveAdjustmentMode
+                : new MixedAdjustmentMode(sdProactiveAdjustmentMode, sdReactiveAdjustmentMode, AdjustmentMode.Adjustment::strongest));
+
+        this.vdAdjustmentMode = vdProactiveAdjustmentMode == null ? vdReactiveAdjustmentMode
+                : (vdReactiveAdjustmentMode == null ? vdProactiveAdjustmentMode
+                : new MixedAdjustmentMode(vdProactiveAdjustmentMode, vdReactiveAdjustmentMode, AdjustmentMode.Adjustment::strongest));
+    }
+
+
+    private static class RatioPreservingAdjustmentMode implements AdjustmentMode {
+        private final double targetRatio;
+        private final Type type;
+        private final AdjustmentMode simulationDistanceAdjustmentMode;
+        private final AdjustmentMode viewDistanceAdjustmentMode;
+        private final SimulationDistanceHook simulationDistanceHook;
+        private final ViewDistanceHook viewDistanceHook;
+
+        private RatioPreservingAdjustmentMode(double targetRatio, Type type, AdjustmentMode simulationDistanceAdjustmentMode, AdjustmentMode viewDistanceAdjustmentMode,SimulationDistanceHook simulationDistanceHook, ViewDistanceHook viewDistanceHook) {
+            this.targetRatio = targetRatio;
+            this.type = type;
+            this.simulationDistanceAdjustmentMode = simulationDistanceAdjustmentMode;
+            this.viewDistanceAdjustmentMode = viewDistanceAdjustmentMode;
+            this.simulationDistanceHook = simulationDistanceHook;
+            this.viewDistanceHook = viewDistanceHook;
+        }
+
+        @Override
+        public Map<World, Adjustment> getAdjustments(Collection<World> worlds, boolean mutate) {
+            if (type == Type.SIMULATION_DISTANCE) {
+                Map<World, Adjustment> adjustmentMap = simulationDistanceAdjustmentMode.getAdjustments(worlds, true);
+                Map<World, Adjustment> viewDistanceAdjustmentMap = viewDistanceAdjustmentMode.getAdjustments(worlds, false);
+                for (World world : worlds) {
+                    if (adjustmentMap.get(world) == Adjustment.INCREASE) {
+                        // cancel the increase if it would put us outside the ratio, unless the view distance is being held up
+                        if ((simulationDistanceHook.getDistance(world) + 1) * targetRatio > viewDistanceHook.getDistance(world)) {
+                            if (viewDistanceAdjustmentMap.get(world) == Adjustment.INCREASE) {
+                                adjustmentMap.put(world, Adjustment.STAY);
+                            }
+                        }
+                    }
+                }
+                return adjustmentMap;
+            } else {
+                Map<World, Adjustment> adjustmentMap = viewDistanceAdjustmentMode.getAdjustments(worlds, true);
+                Map<World, Adjustment> simulationDistanceAdjustmentMap = simulationDistanceAdjustmentMode.getAdjustments(worlds, false);
+                for (World world : worlds) {
+                    if (adjustmentMap.get(world) == Adjustment.DECREASE) {
+                        if (simulationDistanceHook.getDistance(world) * targetRatio > viewDistanceHook.getDistance(world) - 1) {
+                            if (simulationDistanceAdjustmentMap.get(world) == Adjustment.DECREASE) {
+                                adjustmentMap.put(world, Adjustment.STAY);
+                            }
+                        }
+                    }
+                }
+                return adjustmentMap;
+            }
+        }
+
+        enum Type {
+            VIEW_DISTANCE,
+            SIMULATION_DISTANCE
+        }
+
+    }
+
+}

--- a/src/main/java/com/froobworld/viewdistancetweaks/limiter/adjustmentmode/BaseAdjustmentMode.java
+++ b/src/main/java/com/froobworld/viewdistancetweaks/limiter/adjustmentmode/BaseAdjustmentMode.java
@@ -27,25 +27,24 @@ public abstract class BaseAdjustmentMode implements AdjustmentMode {
         this.requiredDecrease = requiredDecrease;
     }
 
-
-    public Adjustment tryIncrease(World world) {
+    protected Adjustment tryIncrease(World world, boolean mutate) {
         if (exclude.apply(world)) {
             return Adjustment.STAY;
         }
-        return getAdjustmentHistory(world).increase() < requiredIncrease ? Adjustment.STAY :
+        return getAdjustmentHistory(world).increase(mutate) < requiredIncrease ? Adjustment.STAY :
                 simulationDistanceHook.getDistance(world) < maximumViewDistance.apply(world) ? Adjustment.INCREASE : Adjustment.STAY;
     }
 
-    public Adjustment tryDecrease(World world) {
+    protected Adjustment tryDecrease(World world, boolean mutate) {
         if (exclude.apply(world)) {
             return Adjustment.STAY;
         }
-        return getAdjustmentHistory(world).decrease() < requiredDecrease ? Adjustment.STAY :
+        return getAdjustmentHistory(world).decrease(mutate) < requiredDecrease ? Adjustment.STAY :
                 simulationDistanceHook.getDistance(world) > minimumViewDistance.apply(world) ? Adjustment.DECREASE : Adjustment.STAY;
     }
 
-    public Adjustment tryStay(World world) {
-        getAdjustmentHistory(world).stay();
+    protected Adjustment tryStay(World world, boolean mutate) {
+        getAdjustmentHistory(world).stay(mutate);
         return Adjustment.STAY;
     }
 
@@ -57,19 +56,28 @@ public abstract class BaseAdjustmentMode implements AdjustmentMode {
         private int increaseCount;
         private int decreaseCount;
 
-        public int increase() {
+        public int increase(boolean mutate) {
+            if (!mutate) {
+                return increaseCount + 1;
+            }
             this.increaseCount++;
             this.decreaseCount = 0;
             return increaseCount;
         }
 
-        public int decrease() {
+        public int decrease(boolean mutate) {
+            if (!mutate) {
+                return increaseCount + 1;
+            }
             this.decreaseCount++;
             this.increaseCount = 0;
             return decreaseCount;
         }
 
-        public void stay() {
+        public void stay(boolean mutate) {
+            if (!mutate) {
+                return;
+            }
             this.increaseCount = 0;
             this.decreaseCount = 0;
         }

--- a/src/main/java/com/froobworld/viewdistancetweaks/limiter/adjustmentmode/MixedAdjustmentMode.java
+++ b/src/main/java/com/froobworld/viewdistancetweaks/limiter/adjustmentmode/MixedAdjustmentMode.java
@@ -19,9 +19,9 @@ public class MixedAdjustmentMode implements AdjustmentMode {
     }
 
     @Override
-    public Map<World, Adjustment> getAdjustments(Collection<World> worlds) {
-        Map<World, Adjustment> adjustments1 = adjustmentMode1.getAdjustments(worlds);
-        Map<World, Adjustment> adjustments2 = adjustmentMode2.getAdjustments(worlds);
+    public Map<World, Adjustment> getAdjustments(Collection<World> worlds, boolean mutate) {
+        Map<World, Adjustment> adjustments1 = adjustmentMode1.getAdjustments(worlds, mutate);
+        Map<World, Adjustment> adjustments2 = adjustmentMode2.getAdjustments(worlds, mutate);
 
         Map<World, Adjustment> finalAdjustments = new HashMap<>(adjustments1);
         for (Map.Entry<World, Adjustment> entry : adjustments2.entrySet()) {

--- a/src/main/java/com/froobworld/viewdistancetweaks/limiter/adjustmentmode/ProactiveAdjustmentMode.java
+++ b/src/main/java/com/froobworld/viewdistancetweaks/limiter/adjustmentmode/ProactiveAdjustmentMode.java
@@ -23,7 +23,7 @@ public class ProactiveAdjustmentMode extends BaseAdjustmentMode {
     }
 
     @Override
-    public Map<World, Adjustment> getAdjustments(Collection<World> worlds) {
+    public Map<World, Adjustment> getAdjustments(Collection<World> worlds, boolean mutate) {
         Map<World, Integer> chunkCounts = new HashMap<>();
         int totalCount = 0;
         for (World world : worlds) {
@@ -36,7 +36,7 @@ public class ProactiveAdjustmentMode extends BaseAdjustmentMode {
             if (totalCount < globalChunkCountTarget) {
                 int newChunkCount = (int) chunkCounter.countChunks(world, simulationDistanceHook.getDistance(world) + 1);
                 int oldCount = chunkCounts.get(world);
-                Adjustment adjustment = tryIncrease(world);
+                Adjustment adjustment = tryIncrease(world, mutate);
 
                 if (totalCount + newChunkCount - oldCount <= globalChunkCountTarget) {
                     adjustments.put(world, adjustment);
@@ -47,7 +47,7 @@ public class ProactiveAdjustmentMode extends BaseAdjustmentMode {
                     adjustments.put(world, Adjustment.STAY);
                 }
             } else if (totalCount > globalChunkCountTarget) {
-                Adjustment adjustment = tryDecrease(world);
+                Adjustment adjustment = tryDecrease(world, mutate);
                 adjustments.put(world, adjustment);
                 if (adjustment == Adjustment.DECREASE) {
                     int newChunkCount = (int) chunkCounter.countChunks(world, simulationDistanceHook.getDistance(world) - 1);
@@ -55,7 +55,7 @@ public class ProactiveAdjustmentMode extends BaseAdjustmentMode {
                     chunkCountDiff = newChunkCount - oldCount;
                 }
             } else {
-                Adjustment adjustment = tryStay(world);
+                Adjustment adjustment = tryStay(world, mutate);
                 adjustments.put(world, adjustment);
             }
             totalCount += chunkCountDiff;

--- a/src/main/java/com/froobworld/viewdistancetweaks/limiter/adjustmentmode/ReactiveAdjustmentMode.java
+++ b/src/main/java/com/froobworld/viewdistancetweaks/limiter/adjustmentmode/ReactiveAdjustmentMode.java
@@ -34,7 +34,7 @@ public class ReactiveAdjustmentMode extends BaseAdjustmentMode {
     }
 
     @Override
-    public Map<World, Adjustment> getAdjustments(Collection<World> worlds) {
+    public Map<World, Adjustment> getAdjustments(Collection<World> worlds, boolean mutate) {
         Map<World, Integer> chunkCounts = new HashMap<>();
         int totalCount = 0;
         for (World world : worlds) {
@@ -49,18 +49,18 @@ public class ReactiveAdjustmentMode extends BaseAdjustmentMode {
             if (mspt <= increaseMsptThreshold) {
                 int additionalChunks = (int) chunkCounter.countChunks(world, simulationDistanceHook.getDistance(world) + 1) - chunkCounts.get(world);
                 if (useMsptChunkHistory && mspt + msptChunkHistory.getMaximumMsptPerChunk() * (totalAdditionalChunks + additionalChunks) >= decreaseMsptThreshold) {
-                    adjustments.put(world, tryStay(world));
+                    adjustments.put(world, tryStay(world, mutate));
                 } else {
-                    Adjustment adjustment = tryIncrease(world);
+                    Adjustment adjustment = tryIncrease(world, mutate);
                     adjustments.put(world, adjustment);
                     if (adjustment == Adjustment.INCREASE) {
                         totalAdditionalChunks += additionalChunks;
                     }
                 }
             } else if (mspt >= decreaseMsptThreshold) {
-                adjustments.put(world, tryDecrease(world));
+                adjustments.put(world, tryDecrease(world, mutate));
             } else {
-                adjustments.put(world, tryStay(world));
+                adjustments.put(world, tryStay(world, mutate));
             }
         }
         msptChunkHistory.purge();

--- a/src/main/resources/resources/config-patches/8.patch
+++ b/src/main/resources/resources/config-patches/8.patch
@@ -1,0 +1,14 @@
+[add-section]
+before=mspt-tracker-settings
+key=reactive-mode-settings.reactive-view-distance
+comment=# These settings concern how view distance should be handled by reactive mode.
+
+[add-field]
+key = reactive-mode-settings.reactive-view-distance.use-reactive-view-distance
+value = false
+comment =# Should we adjust the view distance in reactive mode?\n#  * Note: If set to false, view distance will be adjusted as though proactive mode is active.
+
+[add-field]
+key=reactive-mode-settings.reactive-view-distance.target-view-distance-ratio
+value=2.0
+comment=# What ratio should we try to maintain between the view distance and simulation distance?\n#  * This prevents the simulation distance and view distance bunching up.\n#  * As an example, setting this to 2 would target a view distance which is at least 2x the simulation distance.

--- a/src/main/resources/resources/config.yml
+++ b/src/main/resources/resources/config.yml
@@ -3,7 +3,7 @@
 # Github: https://github.com/froobynooby/ViewDistanceTweaks
 
 # Please don't change this!
-version: 8
+version: 9
 
 # Set this to true to enable the plugin. The plugin is initially disabled so that you can make changes to the config
 # appropriate to your server.
@@ -43,6 +43,17 @@ reactive-mode-settings:
 
   # Above what MSPT should we consider decreasing the simulation distance?
   decrease-mspt-threshold: 47.0
+
+  # These settings concern how view distance should be handled by reactive mode.
+  reactive-view-distance:
+    # Should we adjust the view distance in reactive mode?
+    #  * Note: If set to false, view distance will be adjusted as though proactive mode is active.
+    use-reactive-view-distance: true
+
+    # What ratio should we try to maintain between the view distance and simulation distance?
+    #  * This prevents the simulation distance and view distance bunching up.
+    #  * As an example, setting this to 2 would target a view distance which is at least 2x the simulation distance.
+    target-view-distance-ratio: 2.0
 
   # These settings concern how we determine the server's MSPT.
   #  * Only touch these settings if you know what you're doing.


### PR DESCRIPTION
Adds options as below to make the reactive (and mixed) adjustment mode affect the view distance rather than just the simulation distance. In deciding when to increase or decrease the view distance and simulation distance in reactive mode, the plugin will attempt to maintain a fixed ratio between the view distance and simulation distance. This defaults to 2.0 (i.e. try to have view distance at least 2x that of the simulation distance).

```yaml
  # These settings concern how view distance should be handled by reactive mode.
  reactive-view-distance:
    # Should we adjust the view distance in reactive mode?
    #  * Note: If set to false, view distance will be adjusted as though proactive mode is active.
    use-reactive-view-distance: true

    # What ratio should we try to maintain between the view distance and simulation distance?
    #  * This prevents the simulation distance and view distance bunching up.
    #  * As an example, setting this to 2 would target a view distance which is at least 2x the simulation distance.
    target-view-distance-ratio: 2.0
```

People upgrading the plugin from previous versions will need to switch the `use-reactive-view-distance` option to true to use this feature - upgraded configs default to false to maintain plugin behaviour between versions.

Plugin jar for those who want to test [ViewDistanceTweaks-1.5.7-reactive-vd.zip](https://github.com/user-attachments/files/17228679/ViewDistanceTweaks-1.5.7-reactive-vd.zip).


Fixes #49, #52